### PR TITLE
Fix newline handling in enum_hotfixes

### DIFF
--- a/nxc/modules/enum_hotfixes.py
+++ b/nxc/modules/enum_hotfixes.py
@@ -36,6 +36,10 @@ class NXCModule:
             context.log.debug(f"Executing command: {command}")
             output = connection.execute(command, True)
 
+        # WMIC may introduce carriage returns resulting in extra blank lines
+        if output:
+            output = output.replace("\r\r\n", "\n").replace("\r\n", "\n").replace("\r", "")
+
         if not output:
             context.log.fail("Failed to retrieve hotfix information")
             return


### PR DESCRIPTION
## Summary
- clean WMIC output in `enum_hotfixes` to remove carriage returns

## Testing
- `ruff check nxc/modules/enum_hotfixes.py`
- `pytest -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_6849d4bdeda8832abd339d2fb48e419b